### PR TITLE
Fixed typos

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ it takes a host (default localhost) and a port (default 27017);
 it returns a connection object.
 
 		mongol = require "resty.mongol"
-		conn = mongol:new() -- return a conntion object
+		conn = mongol() -- return a connection object
 
 ###Connection objects have server wide methods.
 ------------


### PR DESCRIPTION
Fixes issue #7:
> after installing it with luarocks i was able to use this module only this way:
> 
> mongodb = require "resty-mongol"
> local monog_conn = mongodb()
> ok,err = monog_conn:connect('127.0.0.1', 27017)