### PR TITLE
Remove duplicate fields in BSON that break MongoDb 4.0

### DIFF
--- a/src/misc.lua
+++ b/src/misc.lua
@@ -1,3 +1,18 @@
+local skip_duplicate = function ( t, sk, k )
+  local nk, nv
+  if k then
+    nk, nv = next(t, k)
+  else
+    nk, nv = next(t)
+  end
+
+  while nk and nk == sk do
+    nk, nv = next(t, nk)
+  end
+  return nk, nv
+end
+
+-- substitute pairs function to bump up the provided argument to be the first item in the list
 local pairs_start = function ( t , sk )
   local i = 0
   return function(t, k, v)
@@ -6,9 +21,9 @@ local pairs_start = function ( t , sk )
     if i == 1 then
       return sk, t[sk]
     elseif i == 2 then
-      nk, nv = next(t)
+      nk, nv = skip_duplicate( t, sk )
     else
-      nk, nv = next(t, k)
+      nk, nv = skip_duplicate( t, sk, k )
     end
     return nk,nv
   end,


### PR DESCRIPTION
The col:count() and the authenticate functions use the function `attachpairs_start`  to construct the message to the MongoDb server.   This works in our old instance of MongoDb 2.4 but fails in MongoDb 3.x and MongoDb 4.0.   Analysis showed that the modified `pairs` function was duplicating entries e.g.

`{  "count": "collectionname",  "count": "collectionname", "query":"something" }
`

This apparently now is prohibited in MongoDb.  The col:count() method (for example) silently fails due to MongoDb error message about duplicate BSON field names.   (Authenticate also fails with a similar message).

The corrections attached still perform the original intent (as best as I can figure out) of moving the named field to the start of the list, but skip it when encountered again.  We were able to successfully call col:count() once this patch was applied.